### PR TITLE
mod_fastcgi: The patch should be applied for El Capitan as well

### DIFF
--- a/mod_fastcgi.rb
+++ b/mod_fastcgi.rb
@@ -58,7 +58,7 @@ class ModFastcgi < Formula
     end
   end
 
-  if MacOS.version == :yosemite || build.with?("homebrew-httpd24")
+  if MacOS.version == :yosemite || MacOS.version == :el_capitan || build.with?("homebrew-httpd24")
     patch do
       url "https://raw.githubusercontent.com/ByteInternet/libapache-mod-fastcgi/byte/debian/patches/byte-compile-against-apache24.diff"
       sha256 "e405f365fac2d80c181a7ddefc9c6332cac7766cb9c67c464c272d595cde1800"


### PR DESCRIPTION
I had the same issue with El Capitan. The patch fixed my issue. 

Note: I'm not too sure that you can write `MacOS.version == :el_capitan`. 

Ref: #47, #48 
