### PR TITLE
HTTP24 2.4.18

### DIFF
--- a/httpd24.rb
+++ b/httpd24.rb
@@ -1,7 +1,7 @@
 class Httpd24 < Formula
   homepage "https://httpd.apache.org/"
-  url "https://archive.apache.org/dist/httpd/httpd-2.4.17.tar.bz2"
-  sha256 "331e035dec81d3db95b048f036f4d7b1a97ec8daa5b377bde42d4ccf1f2eb798"
+  url "https://archive.apache.org/dist/httpd/httpd-2.4.16.tar.bz2"
+  sha256 "ac660b47aaa7887779a6430404dcb40c0b04f90ea69e7bd49a40552e9ff13743"
 
   bottle do
     sha256 "a7744efed0e6bd8dc4eb6926a0f678593b6f18587dde83dc4a902036601f7eb2" => :yosemite

--- a/httpd24.rb
+++ b/httpd24.rb
@@ -149,6 +149,6 @@ class Httpd24 < Formula
   end
 
   test do
-    system sbin/"httpd", "-v"
+    system bin/"httpd", "-v"
   end
 end

--- a/httpd24.rb
+++ b/httpd24.rb
@@ -1,8 +1,8 @@
 class Httpd24 < Formula
   desc "HTTP server"
   homepage "https://httpd.apache.org/"
-  url "https://archive.apache.org/dist/httpd/httpd-2.4.16.tar.bz2"
-  sha256 "ac660b47aaa7887779a6430404dcb40c0b04f90ea69e7bd49a40552e9ff13743"
+  url "https://archive.apache.org/dist/httpd/httpd-2.4.18.tar.bz2"
+  sha256 "0644b050de41f5c9f67c825285049b144690421acb709b06fe53eddfa8a9fd4c"
 
   bottle do
     revision 1


### PR DESCRIPTION
Update httpd24 to 2.4.18 from 2.4.16. Supposedly fixes behavioural changes made in 2.4.17 that broke REDIRECT_URL.