### PR TITLE
add EnvironmentVariables Key to the plist

### DIFF
--- a/httpd24.rb
+++ b/httpd24.rb
@@ -120,6 +120,11 @@ class Httpd24 < Formula
     <dict>
       <key>Label</key>
       <string>#{plist_name}</string>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>PATH</key>
+        <string>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin</string>
+      </dict>
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/httpd</string>


### PR DESCRIPTION
Add EnvironmentVariables for appending /usr/local/bin to the PATH environment variable.
It solves the access of ghostscript by imagemagick in php. See: https://www.euperia.com/development/solved-php-imagick-unable-to-open-image-pdf