### PR TITLE
Update Apache 2.4.25 to 2.4.26 and 2.2.31 to 2.2.32

### DIFF
--- a/ab.rb
+++ b/ab.rb
@@ -1,8 +1,8 @@
 class Ab < Formula
   desc "Apache HTTP server benchmarking tool"
   homepage "https://httpd.apache.org/docs/trunk/programs/ab.html"
-  url "https://archive.apache.org/dist/httpd/httpd-2.4.25.tar.bz2"
-  sha256 "f87ec2df1c9fee3e6bfde3c8b855a3ddb7ca1ab20ca877bd0e2b6bf3f05c80b2"
+  url "https://archive.apache.org/dist/httpd/httpd-2.4.26.tar.bz2"
+  sha256 "a07eb52fafc879e0149d31882f7da63173e72df4478db4dc69f7a775b663d387"
 
   bottle do
     cellar :any

--- a/httpd22.rb
+++ b/httpd22.rb
@@ -1,8 +1,8 @@
 class Httpd22 < Formula
   desc "HTTP server"
   homepage "https://httpd.apache.org/"
-  url "https://archive.apache.org/dist/httpd/httpd-2.2.31.tar.bz2"
-  sha256 "f32f9d19f535dac63b06cb55dfc023b40dcd28196b785f79f9346779e22f26ac"
+  url "https://archive.apache.org/dist/httpd/httpd-2.2.32.tar.bz2"
+  sha256 "527bc9d8092d784daf08910dd6c9d2681d6a2325055b2cc69806a0a7df7ed650"
 
   bottle do
     sha256 "b467425b4c729c842953d4974725cf043006c05cdcb2b973daeb9b4ea12f61bc" => :yosemite

--- a/httpd24.rb
+++ b/httpd24.rb
@@ -1,8 +1,8 @@
 class Httpd24 < Formula
   desc "HTTP server"
   homepage "https://httpd.apache.org/"
-  url "https://archive.apache.org/dist/httpd/httpd-2.4.25.tar.bz2"
-  sha256 "f87ec2df1c9fee3e6bfde3c8b855a3ddb7ca1ab20ca877bd0e2b6bf3f05c80b2"
+  url "https://archive.apache.org/dist/httpd/httpd-2.4.26.tar.bz2"
+  sha256 "a07eb52fafc879e0149d31882f7da63173e72df4478db4dc69f7a775b663d387"
 
   bottle do
     sha256 "d0337466b0b0f843e815afb834d6d6238bdaeb1053dc30e8b8e4b3fe5f1dcdb9" => :sierra


### PR DESCRIPTION
Fixed in Apache httpd 2.4.26
important: ap_get_basic_auth_pw() Authentication Bypass CVE-2017-3167